### PR TITLE
case:修改请求时增加requestCode，方便判断返回的操作

### DIFF
--- a/permission/src/main/java/com/yanzhenjie/permission/LRequest.java
+++ b/permission/src/main/java/com/yanzhenjie/permission/LRequest.java
@@ -82,6 +82,12 @@ class LRequest implements Request {
         return this;
     }
 
+    @NonNull
+    @Override
+    public Request permissionRequestCode(int requestCode) {
+        return this;
+    }
+
     @Override
     public void start() {
         List<String> deniedList = getDeniedPermissions(mSource, mPermissions);

--- a/permission/src/main/java/com/yanzhenjie/permission/MRequest.java
+++ b/permission/src/main/java/com/yanzhenjie/permission/MRequest.java
@@ -15,6 +15,7 @@
  */
 package com.yanzhenjie.permission;
 
+import android.app.Activity;
 import android.os.Build;
 import android.support.annotation.NonNull;
 import android.support.annotation.RequiresApi;
@@ -48,6 +49,7 @@ class MRequest implements Request, RequestExecutor, PermissionActivity.Permissio
     private Action mDenied;
 
     private String[] mDeniedPermissions;
+    private int mPermissionCode;
 
     MRequest(Source source) {
         this.mSource = source;
@@ -93,6 +95,13 @@ class MRequest implements Request, RequestExecutor, PermissionActivity.Permissio
         return this;
     }
 
+    @NonNull
+    @Override
+    public Request permissionRequestCode(int requestCode) {
+        this.mPermissionCode = requestCode;
+        return this;
+    }
+
     @Override
     public void start() {
         List<String> deniedList = getDeniedPermissions(CHECKER, mSource, mPermissions);
@@ -112,7 +121,11 @@ class MRequest implements Request, RequestExecutor, PermissionActivity.Permissio
     @RequiresApi(api = Build.VERSION_CODES.M)
     @Override
     public void execute() {
-        PermissionActivity.requestPermission(mSource.getContext(), mDeniedPermissions, this);
+        if (mPermissionCode != 0 && mSource.getContext() instanceof Activity) {
+            PermissionActivity.requestPermission((Activity) mSource.getContext(), mDeniedPermissions, this, mPermissionCode);
+        } else {
+            PermissionActivity.requestPermission(mSource.getContext(), mDeniedPermissions, this);
+        }
     }
 
     @Override

--- a/permission/src/main/java/com/yanzhenjie/permission/PermissionActivity.java
+++ b/permission/src/main/java/com/yanzhenjie/permission/PermissionActivity.java
@@ -54,6 +54,22 @@ public final class PermissionActivity extends Activity {
         context.startActivity(intent);
     }
 
+    /**
+     * Request for permissions with requestCode
+     * @param activity
+     * @param permissions
+     * @param permissionListener
+     * @param requestCode
+     */
+    public static void requestPermission(Activity activity, String[] permissions, PermissionListener permissionListener, int requestCode) {
+        sPermissionListener = permissionListener;
+
+        Intent intent = new Intent(activity, PermissionActivity.class);
+        intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+        intent.putExtra(KEY_INPUT_PERMISSIONS, permissions);
+        activity.startActivityForResult(intent, requestCode);
+    }
+
     @Override
     protected void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);

--- a/permission/src/main/java/com/yanzhenjie/permission/Request.java
+++ b/permission/src/main/java/com/yanzhenjie/permission/Request.java
@@ -54,6 +54,14 @@ public interface Request {
     Request onDenied(Action denied);
 
     /**
+     * set start PermissionActivity requestCode
+     * @param requestCode
+     * @return
+     */
+    @NonNull
+    Request permissionRequestCode(int requestCode);
+
+    /**
      * Request permission.
      */
     void start();

--- a/permission/src/main/java/com/yanzhenjie/permission/SettingService.java
+++ b/permission/src/main/java/com/yanzhenjie/permission/SettingService.java
@@ -27,6 +27,12 @@ public interface SettingService {
     void execute();
 
     /**
+     * Execute setting with requestCode
+     * @param requestCode
+     */
+    void execute(int requestCode);
+
+    /**
      * Cancel the operation.
      */
     void cancel();

--- a/permission/src/main/java/com/yanzhenjie/permission/setting/PermissionSetting.java
+++ b/permission/src/main/java/com/yanzhenjie/permission/setting/PermissionSetting.java
@@ -15,6 +15,7 @@
  */
 package com.yanzhenjie.permission.setting;
 
+import android.app.Activity;
 import android.content.ComponentName;
 import android.content.Context;
 import android.content.Intent;
@@ -42,6 +43,27 @@ public class PermissionSetting implements SettingService {
 
     @Override
     public void execute() {
+        Intent intent = getPermissionIntent();
+        try {
+            mSource.startActivity(intent);
+        } catch (Exception e) {
+            mSource.startActivity(defaultApi(mSource.getContext()));
+        }
+    }
+
+    @Override
+    public void execute(int requestCode) {
+        Intent intent = getPermissionIntent();
+        if (mSource.getContext() instanceof Activity) {
+            try {
+                ((Activity) mSource.getContext()).startActivityForResult(intent, requestCode);
+            } catch (Exception e) {
+                ((Activity) mSource.getContext()).startActivityForResult(defaultApi(mSource.getContext()), requestCode);
+            }
+        }
+    }
+
+    private Intent getPermissionIntent() {
         Intent intent;
         if (MARK.contains("huawei")) {
             intent = huaweiApi(mSource.getContext());
@@ -60,11 +82,7 @@ public class PermissionSetting implements SettingService {
         } else {
             intent = defaultApi(mSource.getContext());
         }
-        try {
-            mSource.startActivity(intent);
-        } catch (Exception e) {
-            mSource.startActivity(defaultApi(mSource.getContext()));
-        }
+        return intent;
     }
 
     @Override


### PR DESCRIPTION
1. 在进行权限请求时，在跳转到permissionActivity申请权限时，增加requestCode，例如：需要在Activityd的onResume中申请权限时，通过requestcode来判断是从那个页面返回的；
2. 增加设置权限时的requestCode，用于判断是否是从设置页面返回；