### PR TITLE
If the device is a pad without phone capability, StrictChecker will never pass.

### DIFF
--- a/permission/src/main/java/com/yanzhenjie/permission/checker/PhoneStateReadTest.java
+++ b/permission/src/main/java/com/yanzhenjie/permission/checker/PhoneStateReadTest.java
@@ -35,6 +35,11 @@ class PhoneStateReadTest implements PermissionTest {
     @Override
     public boolean test() throws Throwable {
         TelephonyManager service = (TelephonyManager) mContext.getSystemService(Context.TELEPHONY_SERVICE);
-        return !TextUtils.isEmpty(service.getDeviceId()) || !TextUtils.isEmpty(service.getSubscriberId());
+        if (service.getPhoneType() == TelephonyManager.PHONE_TYPE_NONE) {
+            return true;
+        } else {
+            return !TextUtils.isEmpty(service.getDeviceId())
+                    || !TextUtils.isEmpty(service.getSubscriberId());
+        }
     }
 }


### PR DESCRIPTION
If the device is a pad without phone capability, StrictChecker will never pass. 
The solution is, firstly getting the phone type. If the phone type is `PHONE_TYPE_NONE`, we figure out the device has no phone capability, e.g. pad, then just pass this check.
As this strict check is used in `DoubleChecker`, which also has a standard checker, we can guarantee the `READ_PHONE_STATE` is checked by `StandardChecker`, when the device is a pad without phone capability.
This case happens on Samsung's Galaxy Tab S2, Android 7.0