### PR TITLE
add onError method when onGranted() method throw exception

### DIFF
--- a/support/src/main/java/com/yanzhenjie/permission/runtime/LRequest.java
+++ b/support/src/main/java/com/yanzhenjie/permission/runtime/LRequest.java
@@ -41,6 +41,7 @@ class LRequest implements PermissionRequest {
     private String[] mPermissions;
     private Action<List<String>> mGranted;
     private Action<List<String>> mDenied;
+    private Action<Exception> mError;
 
     LRequest(Source source) {
         this.mSource = source;
@@ -66,6 +67,12 @@ class LRequest implements PermissionRequest {
     @Override
     public PermissionRequest onDenied(Action<List<String>> denied) {
         this.mDenied = denied;
+        return this;
+    }
+
+    @Override
+    public PermissionRequest onError(Action<Exception> error) {
+        this.mError = error;
         return this;
     }
 
@@ -98,7 +105,9 @@ class LRequest implements PermissionRequest {
                 mGranted.onAction(permissionList);
             } catch (Exception e) {
                 Log.e("AndPermission", "Please check the onGranted() method body for bugs.", e);
-                if (mDenied != null) {
+                if (mError != null) {
+                    mError.onAction(e);
+                } else if (mDenied != null) {
                     mDenied.onAction(permissionList);
                 }
             }

--- a/support/src/main/java/com/yanzhenjie/permission/runtime/MRequest.java
+++ b/support/src/main/java/com/yanzhenjie/permission/runtime/MRequest.java
@@ -53,6 +53,7 @@ class MRequest implements PermissionRequest, RequestExecutor, BridgeRequest.Call
     };
     private Action<List<String>> mGranted;
     private Action<List<String>> mDenied;
+    private Action<Exception> mError;
 
     private String[] mDeniedPermissions;
 
@@ -81,6 +82,12 @@ class MRequest implements PermissionRequest, RequestExecutor, BridgeRequest.Call
     @Override
     public PermissionRequest onDenied(Action<List<String>> denied) {
         this.mDenied = denied;
+        return this;
+    }
+
+    @Override
+    public PermissionRequest onError(Action<Exception> error) {
+        this.mError = error;
         return this;
     }
 
@@ -143,7 +150,9 @@ class MRequest implements PermissionRequest, RequestExecutor, BridgeRequest.Call
                 mGranted.onAction(permissionList);
             } catch (Exception e) {
                 Log.e("AndPermission", "Please check the onGranted() method body for bugs.", e);
-                if (mDenied != null) {
+                if (mError != null) {
+                    mError.onAction(e);
+                } else if (mDenied != null) {
                     mDenied.onAction(permissionList);
                 }
             }

--- a/support/src/main/java/com/yanzhenjie/permission/runtime/PermissionRequest.java
+++ b/support/src/main/java/com/yanzhenjie/permission/runtime/PermissionRequest.java
@@ -47,6 +47,11 @@ public interface PermissionRequest {
     PermissionRequest onDenied(Action<List<String>> denied);
 
     /**
+     * Action to be taken when onGranted throw exception.
+     */
+    PermissionRequest onError(Action<Exception> error);
+
+    /**
      * Request permission.
      */
     void start();

--- a/x/src/main/java/com/yanzhenjie/permission/runtime/LRequest.java
+++ b/x/src/main/java/com/yanzhenjie/permission/runtime/LRequest.java
@@ -41,6 +41,7 @@ class LRequest implements PermissionRequest {
     private String[] mPermissions;
     private Action<List<String>> mGranted;
     private Action<List<String>> mDenied;
+    private Action<Exception> mError;
 
     LRequest(Source source) {
         this.mSource = source;
@@ -66,6 +67,12 @@ class LRequest implements PermissionRequest {
     @Override
     public PermissionRequest onDenied(Action<List<String>> denied) {
         this.mDenied = denied;
+        return this;
+    }
+
+    @Override
+    public PermissionRequest onError(Action<Exception> error) {
+        this.mError = error;
         return this;
     }
 
@@ -98,7 +105,9 @@ class LRequest implements PermissionRequest {
                 mGranted.onAction(permissionList);
             } catch (Exception e) {
                 Log.e("AndPermission", "Please check the onGranted() method body for bugs.", e);
-                if (mDenied != null) {
+                if (mError != null) {
+                    mError.onAction(e);
+                } else if (mDenied != null) {
                     mDenied.onAction(permissionList);
                 }
             }

--- a/x/src/main/java/com/yanzhenjie/permission/runtime/MRequest.java
+++ b/x/src/main/java/com/yanzhenjie/permission/runtime/MRequest.java
@@ -53,6 +53,7 @@ class MRequest implements PermissionRequest, RequestExecutor, BridgeRequest.Call
     };
     private Action<List<String>> mGranted;
     private Action<List<String>> mDenied;
+    private Action<Exception> mError;
 
     private String[] mDeniedPermissions;
 
@@ -81,6 +82,12 @@ class MRequest implements PermissionRequest, RequestExecutor, BridgeRequest.Call
     @Override
     public PermissionRequest onDenied(Action<List<String>> denied) {
         this.mDenied = denied;
+        return this;
+    }
+
+    @Override
+    public PermissionRequest onError(Action<Exception> error) {
+        this.mError = error;
         return this;
     }
 
@@ -143,7 +150,9 @@ class MRequest implements PermissionRequest, RequestExecutor, BridgeRequest.Call
                 mGranted.onAction(permissionList);
             } catch (Exception e) {
                 Log.e("AndPermission", "Please check the onGranted() method body for bugs.", e);
-                if (mDenied != null) {
+                if (mError != null) {
+                    mError.onAction(e);
+                } else if (mDenied != null) {
                     mDenied.onAction(permissionList);
                 }
             }

--- a/x/src/main/java/com/yanzhenjie/permission/runtime/PermissionRequest.java
+++ b/x/src/main/java/com/yanzhenjie/permission/runtime/PermissionRequest.java
@@ -47,6 +47,11 @@ public interface PermissionRequest {
     PermissionRequest onDenied(Action<List<String>> denied);
 
     /**
+     * Action to be taken when onGranted throw exception.
+     */
+    PermissionRequest onError(Action<Exception> error);
+
+    /**
      * Request permission.
      */
     void start();


### PR DESCRIPTION
增加onError方法，用以处理onGranted方法捕获的exception，避免因非权限exception最终走了onDenied方法，让使用者产生了权限判断没起作用的误解。

已兼容旧版本，用户升级无需修改以往的调用代码。

-------
或者建议删除对onGranted方法的异常捕获处理，在我看来这个是非权限异常了，不合适交给这个框架自身处理。