### PR TITLE
fix camera permission check

### DIFF
--- a/permission/src/main/java/com/yanzhenjie/permission/checker/CameraTest.java
+++ b/permission/src/main/java/com/yanzhenjie/permission/checker/CameraTest.java
@@ -15,9 +15,11 @@
  */
 package com.yanzhenjie.permission.checker;
 
+import android.Manifest;
 import android.content.Context;
 import android.content.pm.PackageManager;
-import android.hardware.Camera;
+
+import androidx.core.content.ContextCompat;
 
 /**
  * Created by Zhenjie Yan on 2018/1/15.
@@ -31,44 +33,8 @@ class CameraTest implements PermissionTest {
     }
 
     @Override
-    public boolean test() throws Throwable {
-        Camera camera = null;
-        try {
-            int cameraCount = Camera.getNumberOfCameras();
-            if (cameraCount <= 0) return true;
-
-            camera = open(cameraCount);
-            Camera.Parameters parameters = camera.getParameters();
-            camera.setParameters(parameters);
-            camera.setPreviewCallback(PREVIEW_CALLBACK);
-            camera.startPreview();
-            return true;
-        } catch (Throwable e) {
-            PackageManager packageManager = mContext.getPackageManager();
-            return !packageManager.hasSystemFeature(PackageManager.FEATURE_CAMERA);
-        } finally {
-            if (camera != null) {
-                camera.stopPreview();
-                camera.setPreviewCallback(null);
-                camera.release();
-            }
-        }
-    }
-
-    private static final Camera.PreviewCallback PREVIEW_CALLBACK = new Camera.PreviewCallback() {
-        @Override
-        public void onPreviewFrame(byte[] data, Camera camera) {
-        }
-    };
-
-    public static Camera open(int count) {
-        Camera.CameraInfo cameraInfo = new Camera.CameraInfo();
-        for (int i = 0; i < count; i++) {
-            Camera.getCameraInfo(i, cameraInfo);
-            if (cameraInfo.facing == Camera.CameraInfo.CAMERA_FACING_BACK) {
-                return Camera.open(i);
-            }
-        }
-        return Camera.open(0);
+    public boolean test() {
+        int hasWriteStoragePermission = ContextCompat.checkSelfPermission(mContext, Manifest.permission.CAMERA);
+        return hasWriteStoragePermission == PackageManager.PERMISSION_GRANTED;
     }
 }


### PR DESCRIPTION
change PermissionTest about camera permission 
 
修复在低端机型上，申请完权限立刻去创建Camera奔溃的问题，比如小米6、红米5

#572 
#532
修复有升降摄像头的手机，调用Camera就会弹出摄像头的问题

#579
这个也许会有改善，待验证



