### PR TITLE
Fix a bug on Storage Permission in Android 11 because of Deprecated API 

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,1 @@
+android.useAndroidX=true

--- a/permission/src/main/java/com/yanzhenjie/permission/checker/StorageWriteTest.java
+++ b/permission/src/main/java/com/yanzhenjie/permission/checker/StorageWriteTest.java
@@ -15,6 +15,7 @@
  */
 package com.yanzhenjie.permission.checker;
 
+import android.content.Context;
 import android.os.Build;
 import android.os.Environment;
 import android.text.TextUtils;
@@ -26,7 +27,10 @@ import java.io.File;
  */
 class StorageWriteTest implements PermissionTest {
 
-    StorageWriteTest() {
+    private Context mContext;
+
+    StorageWriteTest(Context c) {
+        mContext = c;
     }
 
     @Override
@@ -35,7 +39,8 @@ class StorageWriteTest implements PermissionTest {
 
         if (!TextUtils.equals(Environment.MEDIA_MOUNTED, Environment.getExternalStorageState())) return true;
 
-        File directory = Environment.getExternalStorageDirectory();
+        File directory = mContext.getExternalFilesDir(null);
+
         if (!directory.exists()) return true;
 
         File parent = new File(directory, "Android");

--- a/permission/src/main/java/com/yanzhenjie/permission/checker/StrictChecker.java
+++ b/permission/src/main/java/com/yanzhenjie/permission/checker/StrictChecker.java
@@ -105,7 +105,7 @@ public final class StrictChecker implements PermissionChecker {
                 case Permission.READ_EXTERNAL_STORAGE:
                     return checkReadStorage();
                 case Permission.WRITE_EXTERNAL_STORAGE:
-                    return checkWriteStorage();
+                    return checkWriteStorage(context);
             }
         } catch (Throwable e) {
             return false;
@@ -194,8 +194,8 @@ public final class StrictChecker implements PermissionChecker {
         return test.test();
     }
 
-    private static boolean checkWriteStorage() throws Throwable {
-        PermissionTest test = new StorageWriteTest();
+    private static boolean checkWriteStorage(Context context) throws Throwable {
+        PermissionTest test = new StorageWriteTest(context);
         return test.test();
     }
 }


### PR DESCRIPTION
⁠Environment.getExternalStorageDirectory() is a deprecated API, and so this SDK is not working properly in Android 11 during requesting Storage Permissions when targetSdk <29.

This PR migrate the ⁠Environment.getExternalStorageDirectory() to Context.getExternalFilesDir(String)